### PR TITLE
faster round_value

### DIFF
--- a/classes/cLib.lua
+++ b/classes/cLib.lua
@@ -269,12 +269,12 @@ function cLib.least_common(t)
 end
 
 ---------------------------------------------------------------------------------------------------
--- [Static] Round value (from http://lua-users.org/wiki/SimpleRound)
+-- [Static] Round value
 -- @param num (number)
 
 function cLib.round_value(num) 
-  if num >= 0 then return math.floor(num+.5) 
-  else return math.ceil(num-.5) end
+  local frac = num % 1
+  return frac < 0.5 and num - frac or num + 1 - frac
 end
 
 ---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Seems to cut about 1/3 of the time.

The very fastest would simply be floor(num+0.5) with math.floor being cached, but it's only slightly faster than my suggestion. And btw, all of these variations seem to handle negative values perfectly fine in Lua 5.1, contrary to what someone said (? please verify).