### PR TITLE
docs: fix link to cLib Lua Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The library contains methods for working with the file system, basic data-types 
 ## Documentation
 
 Point your browser to this location to browse the auto-generated luadocs:
-https://renoise.github.io/luadocs/clib
+https://renoise.github.io/libraries/clib/
 
 ## Debugging with cLib
 


### PR DESCRIPTION
Lua Documentation URL in README.md is pointing to a broken link.

The updated URL is now in line as per the Renoise github home page.